### PR TITLE
Fixed Starting and Stopping Records/Streams by checking for explict update-type. 

### DIFF
--- a/addons/obs_websocket_gd/obs_ui.gd
+++ b/addons/obs_websocket_gd/obs_ui.gd
@@ -116,30 +116,30 @@ func _on_record_pressed() -> void:
 	match is_recording:
 		true:
 			obs_websocket.send_command("StopRecording")
-			record.text = START_RECORDING
 		false:
 			obs_websocket.send_command("StartRecording")
-			record.text = STOP_RECORDING
 	
-	is_recording = not is_recording
 
 func _on_obs_updated(obs_data: Dictionary) -> void:
 	if (obs_data.has("update-type") and 
 		(obs_data["update-type"] == "SceneItemVisibilityChanged" or obs_data["update-type"] == "TransitionEnd")):
 		yield(get_tree(), "idle_frame")
 		_on_refresh_data_pressed()
-	if obs_data.has("recording") and obs_data["recording"]:
-		record.text = STOP_RECORDING
-		is_recording = true
-	else:
-		record.text = START_RECORDING
-		is_recording = false
-	if obs_data.has("streaming") and obs_data["streaming"]:
-		stream.text = STOP_STREAMING
-		is_streaming = true
-	else:
-		stream.text = START_STREAMING
-		is_streaming = false
+
+	if obs_data.has("update-type"):
+		match obs_data["update-type"]:
+			"RecordingStarted":
+				record.text = STOP_RECORDING
+				is_recording = true
+			"RecordingStopped":
+				record.text = START_RECORDING
+				is_recording = false
+			"StreamingStarted":
+				stream.text = STOP_STREAMING
+				is_streaming = true
+			"StreamingStopped":
+				stream.text = START_STREAMING
+				is_streaming = false
 	print(obs_data)
 
 


### PR DESCRIPTION
PR for #12 

Also removed unneeded lines from _on_record_pressed()

Previously, the `if` condition wasn't being met and an inexplicit `else` was resetting `is_recording` back to `false`.

I decided to use `match` to read `obs_data` and only change states when needed.

I also removed some lines in `_on_record_pressed` as they won't be needed since `_on_obs_updated` updates the state and text anyway.

It would probably be best to change the `SceneItemVisibilityChanged` and `TransitionEnd` to a `match` as well, but I am not currently switching scenes in my project so I haven't tested those yet.