### PR TITLE
Notify user of connection issue.

### DIFF
--- a/addons/obs_websocket_gd/obs_ui.gd
+++ b/addons/obs_websocket_gd/obs_ui.gd
@@ -147,18 +147,6 @@ func _on_obs_updated(obs_data: Dictionary) -> void:
 				is_streaming = false
 	print(obs_data)
 
-###############################################################################
-# Error Handling                                                              #
-###############################################################################
-
-func _on_obs_error(error_msg) -> void:
-	match error_msg:
-		"Authentication Failed.":
-			obs_websocket.break_connection()
-			connect_button.text = CONNECT_TO_OBS
-			error_popup.dialog_text = "Unable to Authenticate to the OBS websocket server.\n\nIs your password correct?"
-			error_popup.popup_centered()
-
 func _on_obs_connected() -> void:
 	obs_websocket.get_scene_list()
 
@@ -236,3 +224,28 @@ func _create_source_button(button_name: String, button_render: bool) -> void:
 ###############################################################################
 # Public functions                                                            #
 ###############################################################################
+
+
+
+###############################################################################
+# Error Handling example                                                      #
+# The client is expected to handle errors.                                    #
+# As such obs_websocket.gd emits a signal called "obs_error" with             #
+# the error information so that obs_ui.gd can decide how to handle it.        #
+###############################################################################
+
+func _on_obs_error(error_msg) -> void:
+	var error_popup = AcceptDialog.new()
+	match error_msg:
+		"Authentication Failed.":
+			obs_websocket.break_connection()
+			connect_button.text = CONNECT_TO_OBS
+			error_popup.dialog_text = "Unable to Authenticate to the OBS websocket server.\n\nIs your password correct?"
+			is_connection_established = false
+		"Connection Error.":
+			obs_websocket.break_connection()
+			connect_button.text = CONNECT_TO_OBS
+			error_popup.dialog_text = "Unable to connect to OBS.\n\nIs OBS running and OBS Websocket installed?"
+			is_connection_established = false
+	self.add_child(error_popup)
+	error_popup.popup_centered()

--- a/addons/obs_websocket_gd/obs_ui.gd
+++ b/addons/obs_websocket_gd/obs_ui.gd
@@ -40,6 +40,8 @@ var is_streaming := false
 onready var record: Button = $VBoxContainer/HBoxContainer/Controls/Record
 var is_recording := false
 
+onready var error_popup : AcceptDialog = get_parent().find_node("ErrorPopup")
+
 onready var engine_version: Dictionary = Engine.get_version_info()
 
 ###############################################################################
@@ -52,6 +54,7 @@ func _ready():
 	obs_websocket.connect("obs_updated", self, "_on_obs_updated")
 	obs_websocket.connect("obs_connected", self, "_on_obs_connected")
 	obs_websocket.connect("obs_scene_list_returned", self, "_on_obs_scene_list_returned")
+	obs_websocket.connect("obs_error", self, "_on_obs_error")
 	
 	# Setup connection values from script
 	host_value.text = obs_websocket.host
@@ -70,6 +73,8 @@ func _ready():
 	
 	record.text = START_RECORDING
 	record.connect("pressed", self, "_on_record_pressed")
+	
+	
 	
 	
 
@@ -142,6 +147,17 @@ func _on_obs_updated(obs_data: Dictionary) -> void:
 				is_streaming = false
 	print(obs_data)
 
+###############################################################################
+# Error Handling                                                              #
+###############################################################################
+
+func _on_obs_error(error_msg) -> void:
+	match error_msg:
+		"Authentication Failed.":
+			obs_websocket.break_connection()
+			connect_button.text = CONNECT_TO_OBS
+			error_popup.dialog_text = "Unable to Authenticate to the OBS websocket server.\n\nIs your password correct?"
+			error_popup.popup_centered()
 
 func _on_obs_connected() -> void:
 	obs_websocket.get_scene_list()

--- a/addons/obs_websocket_gd/obs_ui.gd
+++ b/addons/obs_websocket_gd/obs_ui.gd
@@ -144,10 +144,10 @@ func _on_obs_updated(obs_data: Dictionary) -> void:
 				is_streaming = false
 
 ###############################################################################
-# Error Handling example                                                      #
+# Error Handling example:                                                     #
 # The client is expected to handle errors.                                    #
-# As such obs_websocket.gd emits a signal called "obs_error" with             #
-# the error information so that obs_ui.gd can decide how to handle it.        #
+# obs_websocket.gd emits "obs_updated" which can contain error information    #
+# so that obs_ui.gd can decide how to handle it.                              #
 ###############################################################################
 
 	if obs_data.has("error"):

--- a/addons/obs_websocket_gd/obs_ui.gd
+++ b/addons/obs_websocket_gd/obs_ui.gd
@@ -40,8 +40,6 @@ var is_streaming := false
 onready var record: Button = $VBoxContainer/HBoxContainer/Controls/Record
 var is_recording := false
 
-onready var error_popup : AcceptDialog = get_parent().find_node("ErrorPopup")
-
 onready var engine_version: Dictionary = Engine.get_version_info()
 
 ###############################################################################
@@ -54,7 +52,6 @@ func _ready():
 	obs_websocket.connect("obs_updated", self, "_on_obs_updated")
 	obs_websocket.connect("obs_connected", self, "_on_obs_connected")
 	obs_websocket.connect("obs_scene_list_returned", self, "_on_obs_scene_list_returned")
-	obs_websocket.connect("obs_error", self, "_on_obs_error")
 	
 	# Setup connection values from script
 	host_value.text = obs_websocket.host
@@ -145,6 +142,30 @@ func _on_obs_updated(obs_data: Dictionary) -> void:
 			"StreamingStopped":
 				stream.text = START_STREAMING
 				is_streaming = false
+
+###############################################################################
+# Error Handling example                                                      #
+# The client is expected to handle errors.                                    #
+# As such obs_websocket.gd emits a signal called "obs_error" with             #
+# the error information so that obs_ui.gd can decide how to handle it.        #
+###############################################################################
+
+	if obs_data.has("error"):
+		var error_popup = AcceptDialog.new()
+		match obs_data["error"]:
+			"Authentication Failed.":
+				obs_websocket.break_connection()
+				connect_button.text = CONNECT_TO_OBS
+				error_popup.dialog_text = "Unable to Authenticate to the OBS websocket server.\n\nIs your password correct?"
+				is_connection_established = false
+			"Connection Error.":
+				obs_websocket.break_connection()
+				connect_button.text = CONNECT_TO_OBS
+				error_popup.dialog_text = "Unable to connect to OBS.\n\nIs OBS running and OBS Websocket installed?"
+				is_connection_established = false
+		self.add_child(error_popup)
+		error_popup.popup_centered()
+		
 	print(obs_data)
 
 func _on_obs_connected() -> void:
@@ -224,28 +245,3 @@ func _create_source_button(button_name: String, button_render: bool) -> void:
 ###############################################################################
 # Public functions                                                            #
 ###############################################################################
-
-
-
-###############################################################################
-# Error Handling example                                                      #
-# The client is expected to handle errors.                                    #
-# As such obs_websocket.gd emits a signal called "obs_error" with             #
-# the error information so that obs_ui.gd can decide how to handle it.        #
-###############################################################################
-
-func _on_obs_error(error_msg) -> void:
-	var error_popup = AcceptDialog.new()
-	match error_msg:
-		"Authentication Failed.":
-			obs_websocket.break_connection()
-			connect_button.text = CONNECT_TO_OBS
-			error_popup.dialog_text = "Unable to Authenticate to the OBS websocket server.\n\nIs your password correct?"
-			is_connection_established = false
-		"Connection Error.":
-			obs_websocket.break_connection()
-			connect_button.text = CONNECT_TO_OBS
-			error_popup.dialog_text = "Unable to connect to OBS.\n\nIs OBS running and OBS Websocket installed?"
-			is_connection_established = false
-	self.add_child(error_popup)
-	error_popup.popup_centered()

--- a/addons/obs_websocket_gd/obs_websocket.gd
+++ b/addons/obs_websocket_gd/obs_websocket.gd
@@ -4,7 +4,6 @@ extends Control
 signal obs_connected()
 signal obs_updated(data)
 signal obs_scene_list_returned(data)
-signal obs_error(error)
 
 class ObsObject:
 	var obs_name: String = "changeme"
@@ -149,8 +148,11 @@ func _on_connection_closed(_was_clean_close: bool) -> void:
 	print("OBS connection closed")
 
 func _on_connection_error() -> void:
-	print("OBS connection error")
-	emit_signal("obs_error", "Connection Error.")
+	print("OBS connection error.")
+	# Have to create our own JSON here since this error doesn't return anyway.
+	# This is a copy of the Authentication error, just with Connection in its place.
+	var json_response : Dictionary = {"error":"Connection Error.", "message-id":"1", "status":"error"}
+	emit_signal("obs_updated", json_response)
 
 func _on_connection_established(_protocol: String) -> void:
 	print("OBS connection established")
@@ -167,8 +169,8 @@ func _on_data_received() -> void:
 		return
 		
 	if json_response.has("error"):
+		print(json_response)
 		print("Error: %s" % json_response["error"])
-		emit_signal("obs_error", json_response["error"])
 	
 	if json_response.has("authRequired"):
 		var secret_combined: String = "%s%s" % [password, json_response["salt"]]
@@ -180,7 +182,7 @@ func _on_data_received() -> void:
 	elif (json_response.has("message-id") and json_response["message-id"] == "1"):
 		if json_response["status"] == "ok":
 			emit_signal("obs_connected")
-		return
+			return
 	elif json_response.has("update-type") and json_response["update-type"] == "StreamStatus":
 		return
 

--- a/addons/obs_websocket_gd/obs_websocket.gd
+++ b/addons/obs_websocket_gd/obs_websocket.gd
@@ -150,6 +150,7 @@ func _on_connection_closed(_was_clean_close: bool) -> void:
 
 func _on_connection_error() -> void:
 	print("OBS connection error")
+	emit_signal("obs_error", "Connection Error.")
 
 func _on_connection_established(_protocol: String) -> void:
 	print("OBS connection established")
@@ -166,12 +167,8 @@ func _on_data_received() -> void:
 		return
 		
 	if json_response.has("error"):
-		print("Error: %s" % json_response)
+		print("Error: %s" % json_response["error"])
 		emit_signal("obs_error", json_response["error"])
-		
-		match json_response["error"]:
-			"Authentication Failed.":
-				pass
 	
 	if json_response.has("authRequired"):
 		var secret_combined: String = "%s%s" % [password, json_response["salt"]]

--- a/addons/obs_websocket_gd/obs_websocket.gd
+++ b/addons/obs_websocket_gd/obs_websocket.gd
@@ -4,6 +4,7 @@ extends Control
 signal obs_connected()
 signal obs_updated(data)
 signal obs_scene_list_returned(data)
+signal obs_error(error)
 
 class ObsObject:
 	var obs_name: String = "changeme"
@@ -163,6 +164,14 @@ func _on_data_received() -> void:
 	if typeof(json_response) != TYPE_DICTIONARY:
 		print("Invalid json_response: %s" % json_response)
 		return
+		
+	if json_response.has("error"):
+		print("Error: %s" % json_response)
+		emit_signal("obs_error", json_response["error"])
+		
+		match json_response["error"]:
+			"Authentication Failed.":
+				pass
 	
 	if json_response.has("authRequired"):
 		var secret_combined: String = "%s%s" % [password, json_response["salt"]]

--- a/examples/demo.tscn
+++ b/examples/demo.tscn
@@ -228,7 +228,3 @@ margin_top = 126.0
 margin_right = 244.0
 margin_bottom = 146.0
 text = "Refresh Data"
-
-[node name="ErrorPopup" type="AcceptDialog" parent="."]
-margin_right = 83.0
-margin_bottom = 58.0

--- a/examples/demo.tscn
+++ b/examples/demo.tscn
@@ -215,7 +215,6 @@ margin_left = 124.0
 margin_right = 244.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
-text = "password"
 secret = true
 
 [node name="Connect" type="Button" parent="ObsUi/VBoxContainer/HBoxContainer/Websocket"]
@@ -229,3 +228,7 @@ margin_top = 126.0
 margin_right = 244.0
 margin_bottom = 146.0
 text = "Refresh Data"
+
+[node name="ErrorPopup" type="AcceptDialog" parent="."]
+margin_right = 83.0
+margin_bottom = 58.0


### PR DESCRIPTION
PR for #14 

You shouldn't accept this PR as is, I wanted to show two different options and discuss about which version would be better.

In `obs_websocket.gd` I added a new if conditional `if json_response.has("error")` in the `_on_data_received` function.

You could just send a generic signal with the error and let the client handle it, or you could make a huge match statement with common errors if you want to handle it yourself.

As it is now, the `obs_websocket.gd` is sending a generic error and the "client" `obs_ui.gd` is handling what to do with that information.