### PR TITLE
reset signal connection when websocket connection is broken

### DIFF
--- a/addons/obs-websocket-gd/obs_websocket.gd
+++ b/addons/obs-websocket-gd/obs_websocket.gd
@@ -918,12 +918,21 @@ func _process(delta: float) -> void:
 ###############################################################################
 # Connections                                                                 #
 ###############################################################################
+func _reset_connection():
+	if obs_client.is_connected("data_received", self, "_on_identified_received"):
+		obs_client.disconnect("data_received", self, "_on_identified_received")
+	if obs_client.is_connected("data_received", self, "_on_data_received"):
+		obs_client.disconnect("data_received", self, "_on_data_received")
+	if not obs_client.is_connected("data_received", self, "_on_hello_received"):
+		obs_client.connect("data_received", self, "_on_hello_received")
 
 func _on_connection_closed(_was_clean_close: bool) -> void:
 	logger.info("OBS connection closed")
+	_reset_connection()
 
 func _on_connection_error() -> void:
 	logger.info("OBS connection error")
+	_reset_connection()
 
 func _on_connection_established(protocol: String) -> void:
 	logger.info("OBS connection established with protocol: %s" % protocol)


### PR DESCRIPTION
We should reset the signal connection from `data_received` to `_on_hello_received` whenever websocket connection is broken (error or closed), so the next call to `establish_connection` can succeed.

Thanks for this awesome work. I've been using this with great ease and joy.